### PR TITLE
修复工作簿中第一个表的名称不为“Sheet1”时闪退的情况

### DIFF
--- a/src-tauri/src/app/calarand.rs
+++ b/src-tauri/src/app/calarand.rs
@@ -2,8 +2,8 @@ use crate::app::readers::calareader;
 use log::{debug, error};
 use rand::prelude::*;
 use rtools::{conf::AppConf, exists};
-use std::collections::HashMap;
 use std::sync::Mutex;
+use std::{collections::HashMap, path::PathBuf};
 use tauri::{command, Manager};
 
 // 初始化全局变量
@@ -12,7 +12,10 @@ lazy_static! {
     static ref LIST: Mutex<HashMap<usize, String>> = Mutex::new({
         debug!("初始化全局list变量");
         let config = AppConf::read();
-        let xlsx = calareader::CALA::new().read(config.cala_path).unwrap();
+        let xlsx = calareader::CALA::new().read(config.cala_path).unwrap_or_else(|err|{
+            println!("{err}");
+            calareader::CALA { file_path: PathBuf::new(), content: HashMap::new() }
+        });
         xlsx.content
     });
     // define global record object

--- a/src-tauri/src/app/readers/calareader.rs
+++ b/src-tauri/src/app/readers/calareader.rs
@@ -20,7 +20,9 @@ impl<P: AsRef<Path> + Default> CALA<P> {
         let mut list: HashMap<usize, String> = HashMap::new();
         if (extension == "xlsx") | (extension == "xlsm") | (extension == "xlam") {
             let mut workbook: Xlsx<_> = open_workbook(&path)?;
-            if let Some(Ok(range)) = workbook.worksheet_range("Sheet1") {
+            let for_tablename: Xlsx<_> = open_workbook(&path)?;
+            let tablename = for_tablename.sheet_names();
+            if let Some(Ok(range)) = workbook.worksheet_range(tablename[0].as_str()) {
                 let cell = range.cells();
                 for i in cell {
                     list.insert(i.0, i.2.to_string());
@@ -28,7 +30,9 @@ impl<P: AsRef<Path> + Default> CALA<P> {
             }
         } else if extension == "xls" {
             let mut workbook: Xls<_> = open_workbook(&path)?;
-            if let Some(Ok(range)) = workbook.worksheet_range("Sheet1") {
+            let for_tablename: Xls<_> = open_workbook(&path)?;
+            let tablename = for_tablename.sheet_names();
+            if let Some(Ok(range)) = workbook.worksheet_range(tablename[0].as_str()) {
                 let cell = range.cells();
                 for i in cell {
                     list.insert(i.0, i.2.to_string());


### PR DESCRIPTION
修复工作簿中第一个表的名称不为“Sheet1”时闪退的情况：默认读取工作簿中第一个表